### PR TITLE
Remove markdownify in shortcodes onlyWhen/onlyWhenNot

### DIFF
--- a/layouts/shortcodes/onlyWhen.html
+++ b/layouts/shortcodes/onlyWhen.html
@@ -1,3 +1,3 @@
 {{ if in .Site.Params.enabledModule (.Get 0) }}
-{{ .Inner | markdownify}}
+{{ .Inner }}
 {{ end }}

--- a/layouts/shortcodes/onlyWhenNot.html
+++ b/layouts/shortcodes/onlyWhenNot.html
@@ -1,3 +1,3 @@
 {{ if not (in .Site.Params.enabledModule (.Get 0)) }}
-{{ .Inner | markdownify}}
+{{ .Inner }}
 {{ end }}


### PR DESCRIPTION
This can be achieved with {{% ... %}} instead of {{< ... >}}, see https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown